### PR TITLE
Add analysis routine stubs for person dossiers

### DIFF
--- a/persons/Adrian_Stolz/01_dokumente.md
+++ b/persons/Adrian_Stolz/01_dokumente.md
@@ -1,0 +1,24 @@
+# Adrian Stolz - Dokumente
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basis-Stub gemäß ANALYSE_ROUTINE
+
+---
+
+## Dokumente (chronologisch)
+| Datum | Dokument | Inhalt/Bezug | Pfad/Quelle | Review-Status |
+|-------|----------|--------------|-------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Schlüsseldokumente (Hypothesen)
+- [ ] Relevante Akten aus extracted/ und evidence/ zuordnen.
+- [ ] Abgleich mit Audio-Snippets (falls vorhanden).
+
+---
+
+## Nächste Schritte
+- [ ] Dokumente nach Datum sortieren und bewerten.
+- [ ] Abweichungen zu offiziellen Aussagen markieren.

--- a/persons/Adrian_Stolz/02_audio.md
+++ b/persons/Adrian_Stolz/02_audio.md
@@ -1,0 +1,19 @@
+# Adrian Stolz - Audio-Beweise
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basis-Stub (Suche nach Aliases noch offen)
+
+---
+
+## Audio-Suche (inkl. Aliases)
+| Datum | Datei/Quelle | Kontext | Status | Review-Kommentar |
+|-------|--------------|---------|--------|------------------|
+| - | - | - | offen | Aliase/Schlüsselbegriffe noch prüfen |
+
+---
+
+## Offene Review-Schritte
+- [ ] Snippets in audio/snippets/ prüfen und zuordnen.
+- [ ] Treffer mit Dokumenten (01_dokumente) abgleichen.
+- [ ] Review-Status je Datei setzen (unreviewed/teilweise/gerichtstauglich).

--- a/persons/Adrian_Stolz/03_diskrepanzen.md
+++ b/persons/Adrian_Stolz/03_diskrepanzen.md
@@ -1,0 +1,26 @@
+# Adrian Stolz - Diskrepanz-Analyse
+
+**Erstellt:** 2025-12-24
+**Methode:** Vergleich offizielle Dokumente vs. Audio-Beweise
+**Review:** Basisstruktur vorbereitet
+
+---
+
+## Offiziell vs. Tatsächlich (Platzhalter)
+| Thema | Offizielle Version (Dokumente) | Tatsächlich (Audio/Belege) | Review-Status |
+|-------|--------------------------------|----------------------------|---------------|
+| - | - | - | offen |
+
+---
+
+## Diskrepanz-Backlog
+- [ ] Widersprüche zwischen 01_dokumente und 02_audio sammeln.
+- [ ] Konkrete Beispiele mit Zitaten ergänzen.
+- [ ] Beweiswerte für jede Diskrepanz notieren.
+
+---
+
+## Hinweise für die Auswertung
+- Beide Quellen (Dokumente + Audio) gleichberechtigt prüfen.
+- Datum, Quelle und Zitat immer mit angeben.
+- Review-Kommentare nach jedem Fund ergänzen.

--- a/persons/Adrian_Stolz/04_bewertung.md
+++ b/persons/Adrian_Stolz/04_bewertung.md
@@ -1,0 +1,30 @@
+# Adrian Stolz - Bewertung
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisbewertung angelegt
+
+---
+
+## Bewertungsstand
+- **Credibility Rating (vorläufig):** offen/10
+- **Rolle im Verfahren:** noch einordnen
+- **Aktuelle Einschätzung:** Platzhalter
+
+---
+
+## Zusammenfassung (wird fortgeschrieben)
+- Hinweise aus Dokumenten (01_dokumente) und Audio (02_audio) konsolidieren.
+- Diskrepanzen (03_diskrepanzen) priorisieren.
+
+---
+
+## Offene Fragen
+- [ ] Welche Belege stützen oder widerlegen die offizielle Version?
+- [ ] Welche Zeugen/Audios sind noch zu prüfen?
+
+---
+
+## Empfehlung für DB-Update
+- [ ] Rating und tatsächliche Rolle nach Review setzen.
+- [ ] Notes/Anmerkungen nach Abschluss ergänzen.

--- a/persons/Adrian_Stolz/05_verbindungen.md
+++ b/persons/Adrian_Stolz/05_verbindungen.md
@@ -1,0 +1,23 @@
+# Adrian Stolz - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/Adrian_Stolz/07_motive.md
+++ b/persons/Adrian_Stolz/07_motive.md
@@ -1,0 +1,24 @@
+# Adrian Stolz - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/Aleksandra_Kasprzak/01_dokumente.md
+++ b/persons/Aleksandra_Kasprzak/01_dokumente.md
@@ -1,0 +1,24 @@
+# Aleksandra Kasprzak - Dokumente
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basis-Stub gemäß ANALYSE_ROUTINE
+
+---
+
+## Dokumente (chronologisch)
+| Datum | Dokument | Inhalt/Bezug | Pfad/Quelle | Review-Status |
+|-------|----------|--------------|-------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Schlüsseldokumente (Hypothesen)
+- [ ] Relevante Akten aus extracted/ und evidence/ zuordnen.
+- [ ] Abgleich mit Audio-Snippets (falls vorhanden).
+
+---
+
+## Nächste Schritte
+- [ ] Dokumente nach Datum sortieren und bewerten.
+- [ ] Abweichungen zu offiziellen Aussagen markieren.

--- a/persons/Aleksandra_Kasprzak/02_audio.md
+++ b/persons/Aleksandra_Kasprzak/02_audio.md
@@ -1,0 +1,19 @@
+# Aleksandra Kasprzak - Audio-Beweise
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basis-Stub (Suche nach Aliases noch offen)
+
+---
+
+## Audio-Suche (inkl. Aliases)
+| Datum | Datei/Quelle | Kontext | Status | Review-Kommentar |
+|-------|--------------|---------|--------|------------------|
+| - | - | - | offen | Aliase/Schlüsselbegriffe noch prüfen |
+
+---
+
+## Offene Review-Schritte
+- [ ] Snippets in audio/snippets/ prüfen und zuordnen.
+- [ ] Treffer mit Dokumenten (01_dokumente) abgleichen.
+- [ ] Review-Status je Datei setzen (unreviewed/teilweise/gerichtstauglich).

--- a/persons/Aleksandra_Kasprzak/03_diskrepanzen.md
+++ b/persons/Aleksandra_Kasprzak/03_diskrepanzen.md
@@ -1,0 +1,26 @@
+# Aleksandra Kasprzak - Diskrepanz-Analyse
+
+**Erstellt:** 2025-12-24
+**Methode:** Vergleich offizielle Dokumente vs. Audio-Beweise
+**Review:** Basisstruktur vorbereitet
+
+---
+
+## Offiziell vs. Tatsächlich (Platzhalter)
+| Thema | Offizielle Version (Dokumente) | Tatsächlich (Audio/Belege) | Review-Status |
+|-------|--------------------------------|----------------------------|---------------|
+| - | - | - | offen |
+
+---
+
+## Diskrepanz-Backlog
+- [ ] Widersprüche zwischen 01_dokumente und 02_audio sammeln.
+- [ ] Konkrete Beispiele mit Zitaten ergänzen.
+- [ ] Beweiswerte für jede Diskrepanz notieren.
+
+---
+
+## Hinweise für die Auswertung
+- Beide Quellen (Dokumente + Audio) gleichberechtigt prüfen.
+- Datum, Quelle und Zitat immer mit angeben.
+- Review-Kommentare nach jedem Fund ergänzen.

--- a/persons/Aleksandra_Kasprzak/04_bewertung.md
+++ b/persons/Aleksandra_Kasprzak/04_bewertung.md
@@ -1,0 +1,30 @@
+# Aleksandra Kasprzak - Bewertung
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisbewertung angelegt
+
+---
+
+## Bewertungsstand
+- **Credibility Rating (vorläufig):** offen/10
+- **Rolle im Verfahren:** noch einordnen
+- **Aktuelle Einschätzung:** Platzhalter
+
+---
+
+## Zusammenfassung (wird fortgeschrieben)
+- Hinweise aus Dokumenten (01_dokumente) und Audio (02_audio) konsolidieren.
+- Diskrepanzen (03_diskrepanzen) priorisieren.
+
+---
+
+## Offene Fragen
+- [ ] Welche Belege stützen oder widerlegen die offizielle Version?
+- [ ] Welche Zeugen/Audios sind noch zu prüfen?
+
+---
+
+## Empfehlung für DB-Update
+- [ ] Rating und tatsächliche Rolle nach Review setzen.
+- [ ] Notes/Anmerkungen nach Abschluss ergänzen.

--- a/persons/Aleksandra_Kasprzak/05_verbindungen.md
+++ b/persons/Aleksandra_Kasprzak/05_verbindungen.md
@@ -1,0 +1,23 @@
+# Aleksandra Kasprzak - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/Alexander_Eichberger/02_audio.md
+++ b/persons/Alexander_Eichberger/02_audio.md
@@ -1,0 +1,19 @@
+# Alexander Eichberger - Audio-Beweise
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basis-Stub (Suche nach Aliases noch offen)
+
+---
+
+## Audio-Suche (inkl. Aliases)
+| Datum | Datei/Quelle | Kontext | Status | Review-Kommentar |
+|-------|--------------|---------|--------|------------------|
+| - | - | - | offen | Aliase/Schlüsselbegriffe noch prüfen |
+
+---
+
+## Offene Review-Schritte
+- [ ] Snippets in audio/snippets/ prüfen und zuordnen.
+- [ ] Treffer mit Dokumenten (01_dokumente) abgleichen.
+- [ ] Review-Status je Datei setzen (unreviewed/teilweise/gerichtstauglich).

--- a/persons/Alexander_Eichberger/03_diskrepanzen.md
+++ b/persons/Alexander_Eichberger/03_diskrepanzen.md
@@ -1,0 +1,26 @@
+# Alexander Eichberger - Diskrepanz-Analyse
+
+**Erstellt:** 2025-12-24
+**Methode:** Vergleich offizielle Dokumente vs. Audio-Beweise
+**Review:** Basisstruktur vorbereitet
+
+---
+
+## Offiziell vs. Tatsächlich (Platzhalter)
+| Thema | Offizielle Version (Dokumente) | Tatsächlich (Audio/Belege) | Review-Status |
+|-------|--------------------------------|----------------------------|---------------|
+| - | - | - | offen |
+
+---
+
+## Diskrepanz-Backlog
+- [ ] Widersprüche zwischen 01_dokumente und 02_audio sammeln.
+- [ ] Konkrete Beispiele mit Zitaten ergänzen.
+- [ ] Beweiswerte für jede Diskrepanz notieren.
+
+---
+
+## Hinweise für die Auswertung
+- Beide Quellen (Dokumente + Audio) gleichberechtigt prüfen.
+- Datum, Quelle und Zitat immer mit angeben.
+- Review-Kommentare nach jedem Fund ergänzen.

--- a/persons/Alexander_Eichberger/04_bewertung.md
+++ b/persons/Alexander_Eichberger/04_bewertung.md
@@ -1,0 +1,30 @@
+# Alexander Eichberger - Bewertung
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisbewertung angelegt
+
+---
+
+## Bewertungsstand
+- **Credibility Rating (vorläufig):** offen/10
+- **Rolle im Verfahren:** noch einordnen
+- **Aktuelle Einschätzung:** Platzhalter
+
+---
+
+## Zusammenfassung (wird fortgeschrieben)
+- Hinweise aus Dokumenten (01_dokumente) und Audio (02_audio) konsolidieren.
+- Diskrepanzen (03_diskrepanzen) priorisieren.
+
+---
+
+## Offene Fragen
+- [ ] Welche Belege stützen oder widerlegen die offizielle Version?
+- [ ] Welche Zeugen/Audios sind noch zu prüfen?
+
+---
+
+## Empfehlung für DB-Update
+- [ ] Rating und tatsächliche Rolle nach Review setzen.
+- [ ] Notes/Anmerkungen nach Abschluss ergänzen.

--- a/persons/Alexander_Eichberger/05_verbindungen.md
+++ b/persons/Alexander_Eichberger/05_verbindungen.md
@@ -1,0 +1,23 @@
+# Alexander Eichberger - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/Alexander_Eichberger/06_aussagen.md
+++ b/persons/Alexander_Eichberger/06_aussagen.md
@@ -1,0 +1,19 @@
+# Alexander Eichberger - Aussagen (Wortlaut)
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Struktur laut ANALYSE_ROUTINE angelegt
+
+---
+
+## Aussagen-Tabelle
+| Wortlaut (exakt) | Datum | Quelle Genesis (Dokument) | Quelle Factcheck (Audio) | Beweiswert (1-10) | Verwendung | Review-Status |
+|------------------|-------|---------------------------|--------------------------|-------------------|------------|---------------|
+| - | - | - | - | - | - | offen |
+
+---
+
+## Hinweise für die Befüllung
+- Exakte Zitate verwenden, mit Datum und Quelle.
+- Bei Audio immer Snippet/Datei referenzieren.
+- Verwendungszweck definieren (Anklage, Plädoyer, Presse, Petition).

--- a/persons/Alexander_Eichberger/07_motive.md
+++ b/persons/Alexander_Eichberger/07_motive.md
@@ -1,0 +1,24 @@
+# Alexander Eichberger - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/Beate_Brandt/05_verbindungen.md
+++ b/persons/Beate_Brandt/05_verbindungen.md
@@ -1,0 +1,23 @@
+# Beate Brandt - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/Beate_Brandt/06_aussagen.md
+++ b/persons/Beate_Brandt/06_aussagen.md
@@ -1,0 +1,19 @@
+# Beate Brandt - Aussagen (Wortlaut)
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Struktur laut ANALYSE_ROUTINE angelegt
+
+---
+
+## Aussagen-Tabelle
+| Wortlaut (exakt) | Datum | Quelle Genesis (Dokument) | Quelle Factcheck (Audio) | Beweiswert (1-10) | Verwendung | Review-Status |
+|------------------|-------|---------------------------|--------------------------|-------------------|------------|---------------|
+| - | - | - | - | - | - | offen |
+
+---
+
+## Hinweise für die Befüllung
+- Exakte Zitate verwenden, mit Datum und Quelle.
+- Bei Audio immer Snippet/Datei referenzieren.
+- Verwendungszweck definieren (Anklage, Plädoyer, Presse, Petition).

--- a/persons/Beate_Brandt/07_motive.md
+++ b/persons/Beate_Brandt/07_motive.md
@@ -1,0 +1,24 @@
+# Beate Brandt - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/Frau_Jung/01_dokumente.md
+++ b/persons/Frau_Jung/01_dokumente.md
@@ -1,0 +1,24 @@
+# Frau Jung - Dokumente
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basis-Stub gemäß ANALYSE_ROUTINE
+
+---
+
+## Dokumente (chronologisch)
+| Datum | Dokument | Inhalt/Bezug | Pfad/Quelle | Review-Status |
+|-------|----------|--------------|-------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Schlüsseldokumente (Hypothesen)
+- [ ] Relevante Akten aus extracted/ und evidence/ zuordnen.
+- [ ] Abgleich mit Audio-Snippets (falls vorhanden).
+
+---
+
+## Nächste Schritte
+- [ ] Dokumente nach Datum sortieren und bewerten.
+- [ ] Abweichungen zu offiziellen Aussagen markieren.

--- a/persons/Frau_Jung/02_audio.md
+++ b/persons/Frau_Jung/02_audio.md
@@ -1,0 +1,19 @@
+# Frau Jung - Audio-Beweise
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basis-Stub (Suche nach Aliases noch offen)
+
+---
+
+## Audio-Suche (inkl. Aliases)
+| Datum | Datei/Quelle | Kontext | Status | Review-Kommentar |
+|-------|--------------|---------|--------|------------------|
+| - | - | - | offen | Aliase/Schlüsselbegriffe noch prüfen |
+
+---
+
+## Offene Review-Schritte
+- [ ] Snippets in audio/snippets/ prüfen und zuordnen.
+- [ ] Treffer mit Dokumenten (01_dokumente) abgleichen.
+- [ ] Review-Status je Datei setzen (unreviewed/teilweise/gerichtstauglich).

--- a/persons/Frau_Jung/03_diskrepanzen.md
+++ b/persons/Frau_Jung/03_diskrepanzen.md
@@ -1,0 +1,26 @@
+# Frau Jung - Diskrepanz-Analyse
+
+**Erstellt:** 2025-12-24
+**Methode:** Vergleich offizielle Dokumente vs. Audio-Beweise
+**Review:** Basisstruktur vorbereitet
+
+---
+
+## Offiziell vs. Tatsächlich (Platzhalter)
+| Thema | Offizielle Version (Dokumente) | Tatsächlich (Audio/Belege) | Review-Status |
+|-------|--------------------------------|----------------------------|---------------|
+| - | - | - | offen |
+
+---
+
+## Diskrepanz-Backlog
+- [ ] Widersprüche zwischen 01_dokumente und 02_audio sammeln.
+- [ ] Konkrete Beispiele mit Zitaten ergänzen.
+- [ ] Beweiswerte für jede Diskrepanz notieren.
+
+---
+
+## Hinweise für die Auswertung
+- Beide Quellen (Dokumente + Audio) gleichberechtigt prüfen.
+- Datum, Quelle und Zitat immer mit angeben.
+- Review-Kommentare nach jedem Fund ergänzen.

--- a/persons/Frau_Jung/04_bewertung.md
+++ b/persons/Frau_Jung/04_bewertung.md
@@ -1,0 +1,30 @@
+# Frau Jung - Bewertung
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisbewertung angelegt
+
+---
+
+## Bewertungsstand
+- **Credibility Rating (vorläufig):** offen/10
+- **Rolle im Verfahren:** noch einordnen
+- **Aktuelle Einschätzung:** Platzhalter
+
+---
+
+## Zusammenfassung (wird fortgeschrieben)
+- Hinweise aus Dokumenten (01_dokumente) und Audio (02_audio) konsolidieren.
+- Diskrepanzen (03_diskrepanzen) priorisieren.
+
+---
+
+## Offene Fragen
+- [ ] Welche Belege stützen oder widerlegen die offizielle Version?
+- [ ] Welche Zeugen/Audios sind noch zu prüfen?
+
+---
+
+## Empfehlung für DB-Update
+- [ ] Rating und tatsächliche Rolle nach Review setzen.
+- [ ] Notes/Anmerkungen nach Abschluss ergänzen.

--- a/persons/Frau_Jung/05_verbindungen.md
+++ b/persons/Frau_Jung/05_verbindungen.md
@@ -1,0 +1,23 @@
+# Frau Jung - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/Frau_Jung/06_aussagen.md
+++ b/persons/Frau_Jung/06_aussagen.md
@@ -1,0 +1,19 @@
+# Frau Jung - Aussagen (Wortlaut)
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Struktur laut ANALYSE_ROUTINE angelegt
+
+---
+
+## Aussagen-Tabelle
+| Wortlaut (exakt) | Datum | Quelle Genesis (Dokument) | Quelle Factcheck (Audio) | Beweiswert (1-10) | Verwendung | Review-Status |
+|------------------|-------|---------------------------|--------------------------|-------------------|------------|---------------|
+| - | - | - | - | - | - | offen |
+
+---
+
+## Hinweise für die Befüllung
+- Exakte Zitate verwenden, mit Datum und Quelle.
+- Bei Audio immer Snippet/Datei referenzieren.
+- Verwendungszweck definieren (Anklage, Plädoyer, Presse, Petition).

--- a/persons/Frau_Jung/07_motive.md
+++ b/persons/Frau_Jung/07_motive.md
@@ -1,0 +1,24 @@
+# Frau Jung - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/Heiko_Bluth/01_dokumente.md
+++ b/persons/Heiko_Bluth/01_dokumente.md
@@ -1,0 +1,24 @@
+# Heiko Bluth - Dokumente
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basis-Stub gemäß ANALYSE_ROUTINE
+
+---
+
+## Dokumente (chronologisch)
+| Datum | Dokument | Inhalt/Bezug | Pfad/Quelle | Review-Status |
+|-------|----------|--------------|-------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Schlüsseldokumente (Hypothesen)
+- [ ] Relevante Akten aus extracted/ und evidence/ zuordnen.
+- [ ] Abgleich mit Audio-Snippets (falls vorhanden).
+
+---
+
+## Nächste Schritte
+- [ ] Dokumente nach Datum sortieren und bewerten.
+- [ ] Abweichungen zu offiziellen Aussagen markieren.

--- a/persons/Heiko_Bluth/02_audio.md
+++ b/persons/Heiko_Bluth/02_audio.md
@@ -1,0 +1,19 @@
+# Heiko Bluth - Audio-Beweise
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basis-Stub (Suche nach Aliases noch offen)
+
+---
+
+## Audio-Suche (inkl. Aliases)
+| Datum | Datei/Quelle | Kontext | Status | Review-Kommentar |
+|-------|--------------|---------|--------|------------------|
+| - | - | - | offen | Aliase/Schlüsselbegriffe noch prüfen |
+
+---
+
+## Offene Review-Schritte
+- [ ] Snippets in audio/snippets/ prüfen und zuordnen.
+- [ ] Treffer mit Dokumenten (01_dokumente) abgleichen.
+- [ ] Review-Status je Datei setzen (unreviewed/teilweise/gerichtstauglich).

--- a/persons/Heiko_Bluth/03_diskrepanzen.md
+++ b/persons/Heiko_Bluth/03_diskrepanzen.md
@@ -1,0 +1,26 @@
+# Heiko Bluth - Diskrepanz-Analyse
+
+**Erstellt:** 2025-12-24
+**Methode:** Vergleich offizielle Dokumente vs. Audio-Beweise
+**Review:** Basisstruktur vorbereitet
+
+---
+
+## Offiziell vs. Tatsächlich (Platzhalter)
+| Thema | Offizielle Version (Dokumente) | Tatsächlich (Audio/Belege) | Review-Status |
+|-------|--------------------------------|----------------------------|---------------|
+| - | - | - | offen |
+
+---
+
+## Diskrepanz-Backlog
+- [ ] Widersprüche zwischen 01_dokumente und 02_audio sammeln.
+- [ ] Konkrete Beispiele mit Zitaten ergänzen.
+- [ ] Beweiswerte für jede Diskrepanz notieren.
+
+---
+
+## Hinweise für die Auswertung
+- Beide Quellen (Dokumente + Audio) gleichberechtigt prüfen.
+- Datum, Quelle und Zitat immer mit angeben.
+- Review-Kommentare nach jedem Fund ergänzen.

--- a/persons/Heiko_Bluth/04_bewertung.md
+++ b/persons/Heiko_Bluth/04_bewertung.md
@@ -1,0 +1,30 @@
+# Heiko Bluth - Bewertung
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisbewertung angelegt
+
+---
+
+## Bewertungsstand
+- **Credibility Rating (vorläufig):** offen/10
+- **Rolle im Verfahren:** noch einordnen
+- **Aktuelle Einschätzung:** Platzhalter
+
+---
+
+## Zusammenfassung (wird fortgeschrieben)
+- Hinweise aus Dokumenten (01_dokumente) und Audio (02_audio) konsolidieren.
+- Diskrepanzen (03_diskrepanzen) priorisieren.
+
+---
+
+## Offene Fragen
+- [ ] Welche Belege stützen oder widerlegen die offizielle Version?
+- [ ] Welche Zeugen/Audios sind noch zu prüfen?
+
+---
+
+## Empfehlung für DB-Update
+- [ ] Rating und tatsächliche Rolle nach Review setzen.
+- [ ] Notes/Anmerkungen nach Abschluss ergänzen.

--- a/persons/Heiko_Bluth/05_verbindungen.md
+++ b/persons/Heiko_Bluth/05_verbindungen.md
@@ -1,0 +1,23 @@
+# Heiko Bluth - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/Heiko_Bluth/07_motive.md
+++ b/persons/Heiko_Bluth/07_motive.md
@@ -1,0 +1,24 @@
+# Heiko Bluth - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/Herr_Bohnenberger/01_dokumente.md
+++ b/persons/Herr_Bohnenberger/01_dokumente.md
@@ -1,0 +1,24 @@
+# Herr Bohnenberger - Dokumente
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basis-Stub gemäß ANALYSE_ROUTINE
+
+---
+
+## Dokumente (chronologisch)
+| Datum | Dokument | Inhalt/Bezug | Pfad/Quelle | Review-Status |
+|-------|----------|--------------|-------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Schlüsseldokumente (Hypothesen)
+- [ ] Relevante Akten aus extracted/ und evidence/ zuordnen.
+- [ ] Abgleich mit Audio-Snippets (falls vorhanden).
+
+---
+
+## Nächste Schritte
+- [ ] Dokumente nach Datum sortieren und bewerten.
+- [ ] Abweichungen zu offiziellen Aussagen markieren.

--- a/persons/Herr_Bohnenberger/03_diskrepanzen.md
+++ b/persons/Herr_Bohnenberger/03_diskrepanzen.md
@@ -1,0 +1,26 @@
+# Herr Bohnenberger - Diskrepanz-Analyse
+
+**Erstellt:** 2025-12-24
+**Methode:** Vergleich offizielle Dokumente vs. Audio-Beweise
+**Review:** Basisstruktur vorbereitet
+
+---
+
+## Offiziell vs. Tatsächlich (Platzhalter)
+| Thema | Offizielle Version (Dokumente) | Tatsächlich (Audio/Belege) | Review-Status |
+|-------|--------------------------------|----------------------------|---------------|
+| - | - | - | offen |
+
+---
+
+## Diskrepanz-Backlog
+- [ ] Widersprüche zwischen 01_dokumente und 02_audio sammeln.
+- [ ] Konkrete Beispiele mit Zitaten ergänzen.
+- [ ] Beweiswerte für jede Diskrepanz notieren.
+
+---
+
+## Hinweise für die Auswertung
+- Beide Quellen (Dokumente + Audio) gleichberechtigt prüfen.
+- Datum, Quelle und Zitat immer mit angeben.
+- Review-Kommentare nach jedem Fund ergänzen.

--- a/persons/Herr_Bohnenberger/04_bewertung.md
+++ b/persons/Herr_Bohnenberger/04_bewertung.md
@@ -1,0 +1,30 @@
+# Herr Bohnenberger - Bewertung
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisbewertung angelegt
+
+---
+
+## Bewertungsstand
+- **Credibility Rating (vorläufig):** offen/10
+- **Rolle im Verfahren:** noch einordnen
+- **Aktuelle Einschätzung:** Platzhalter
+
+---
+
+## Zusammenfassung (wird fortgeschrieben)
+- Hinweise aus Dokumenten (01_dokumente) und Audio (02_audio) konsolidieren.
+- Diskrepanzen (03_diskrepanzen) priorisieren.
+
+---
+
+## Offene Fragen
+- [ ] Welche Belege stützen oder widerlegen die offizielle Version?
+- [ ] Welche Zeugen/Audios sind noch zu prüfen?
+
+---
+
+## Empfehlung für DB-Update
+- [ ] Rating und tatsächliche Rolle nach Review setzen.
+- [ ] Notes/Anmerkungen nach Abschluss ergänzen.

--- a/persons/Herr_Bohnenberger/05_verbindungen.md
+++ b/persons/Herr_Bohnenberger/05_verbindungen.md
@@ -1,0 +1,23 @@
+# Herr Bohnenberger - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/Herr_Bohnenberger/06_aussagen.md
+++ b/persons/Herr_Bohnenberger/06_aussagen.md
@@ -1,0 +1,19 @@
+# Herr Bohnenberger - Aussagen (Wortlaut)
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Struktur laut ANALYSE_ROUTINE angelegt
+
+---
+
+## Aussagen-Tabelle
+| Wortlaut (exakt) | Datum | Quelle Genesis (Dokument) | Quelle Factcheck (Audio) | Beweiswert (1-10) | Verwendung | Review-Status |
+|------------------|-------|---------------------------|--------------------------|-------------------|------------|---------------|
+| - | - | - | - | - | - | offen |
+
+---
+
+## Hinweise für die Befüllung
+- Exakte Zitate verwenden, mit Datum und Quelle.
+- Bei Audio immer Snippet/Datei referenzieren.
+- Verwendungszweck definieren (Anklage, Plädoyer, Presse, Petition).

--- a/persons/Herr_Bohnenberger/07_motive.md
+++ b/persons/Herr_Bohnenberger/07_motive.md
@@ -1,0 +1,24 @@
+# Herr Bohnenberger - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/KK_Welde/05_verbindungen.md
+++ b/persons/KK_Welde/05_verbindungen.md
@@ -1,0 +1,23 @@
+# KK Welde - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/KK_Welde/06_aussagen.md
+++ b/persons/KK_Welde/06_aussagen.md
@@ -1,0 +1,19 @@
+# KK Welde - Aussagen (Wortlaut)
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Struktur laut ANALYSE_ROUTINE angelegt
+
+---
+
+## Aussagen-Tabelle
+| Wortlaut (exakt) | Datum | Quelle Genesis (Dokument) | Quelle Factcheck (Audio) | Beweiswert (1-10) | Verwendung | Review-Status |
+|------------------|-------|---------------------------|--------------------------|-------------------|------------|---------------|
+| - | - | - | - | - | - | offen |
+
+---
+
+## Hinweise für die Befüllung
+- Exakte Zitate verwenden, mit Datum und Quelle.
+- Bei Audio immer Snippet/Datei referenzieren.
+- Verwendungszweck definieren (Anklage, Plädoyer, Presse, Petition).

--- a/persons/KK_Welde/07_motive.md
+++ b/persons/KK_Welde/07_motive.md
@@ -1,0 +1,24 @@
+# KK Welde - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/KOK_Richter_Polizeibeamter/05_verbindungen.md
+++ b/persons/KOK_Richter_Polizeibeamter/05_verbindungen.md
@@ -1,0 +1,23 @@
+# KOK Richter Polizeibeamter - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/KOK_Richter_Polizeibeamter/06_aussagen.md
+++ b/persons/KOK_Richter_Polizeibeamter/06_aussagen.md
@@ -1,0 +1,19 @@
+# KOK Richter Polizeibeamter - Aussagen (Wortlaut)
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Struktur laut ANALYSE_ROUTINE angelegt
+
+---
+
+## Aussagen-Tabelle
+| Wortlaut (exakt) | Datum | Quelle Genesis (Dokument) | Quelle Factcheck (Audio) | Beweiswert (1-10) | Verwendung | Review-Status |
+|------------------|-------|---------------------------|--------------------------|-------------------|------------|---------------|
+| - | - | - | - | - | - | offen |
+
+---
+
+## Hinweise für die Befüllung
+- Exakte Zitate verwenden, mit Datum und Quelle.
+- Bei Audio immer Snippet/Datei referenzieren.
+- Verwendungszweck definieren (Anklage, Plädoyer, Presse, Petition).

--- a/persons/KOK_Richter_Polizeibeamter/07_motive.md
+++ b/persons/KOK_Richter_Polizeibeamter/07_motive.md
@@ -1,0 +1,24 @@
+# KOK Richter Polizeibeamter - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/Lena_Kuhn/07_motive.md
+++ b/persons/Lena_Kuhn/07_motive.md
@@ -1,0 +1,24 @@
+# Lena Kuhn - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/Nina_Meiser/05_verbindungen.md
+++ b/persons/Nina_Meiser/05_verbindungen.md
@@ -1,0 +1,23 @@
+# Nina Meiser - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/Nina_Meiser/07_motive.md
+++ b/persons/Nina_Meiser/07_motive.md
@@ -1,0 +1,24 @@
+# Nina Meiser - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/RA_Frank_Schubert/06_aussagen.md
+++ b/persons/RA_Frank_Schubert/06_aussagen.md
@@ -1,0 +1,19 @@
+# RA Frank Schubert - Aussagen (Wortlaut)
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Struktur laut ANALYSE_ROUTINE angelegt
+
+---
+
+## Aussagen-Tabelle
+| Wortlaut (exakt) | Datum | Quelle Genesis (Dokument) | Quelle Factcheck (Audio) | Beweiswert (1-10) | Verwendung | Review-Status |
+|------------------|-------|---------------------------|--------------------------|-------------------|------------|---------------|
+| - | - | - | - | - | - | offen |
+
+---
+
+## Hinweise für die Befüllung
+- Exakte Zitate verwenden, mit Datum und Quelle.
+- Bei Audio immer Snippet/Datei referenzieren.
+- Verwendungszweck definieren (Anklage, Plädoyer, Presse, Petition).

--- a/persons/RA_Frank_Schubert/07_motive.md
+++ b/persons/RA_Frank_Schubert/07_motive.md
@@ -1,0 +1,24 @@
+# RA Frank Schubert - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/RA_Lehne/05_verbindungen.md
+++ b/persons/RA_Lehne/05_verbindungen.md
@@ -1,0 +1,23 @@
+# RA Lehne - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/RA_Lehne/06_aussagen.md
+++ b/persons/RA_Lehne/06_aussagen.md
@@ -1,0 +1,19 @@
+# RA Lehne - Aussagen (Wortlaut)
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Struktur laut ANALYSE_ROUTINE angelegt
+
+---
+
+## Aussagen-Tabelle
+| Wortlaut (exakt) | Datum | Quelle Genesis (Dokument) | Quelle Factcheck (Audio) | Beweiswert (1-10) | Verwendung | Review-Status |
+|------------------|-------|---------------------------|--------------------------|-------------------|------------|---------------|
+| - | - | - | - | - | - | offen |
+
+---
+
+## Hinweise für die Befüllung
+- Exakte Zitate verwenden, mit Datum und Quelle.
+- Bei Audio immer Snippet/Datei referenzieren.
+- Verwendungszweck definieren (Anklage, Plädoyer, Presse, Petition).

--- a/persons/RA_Lehne/07_motive.md
+++ b/persons/RA_Lehne/07_motive.md
@@ -1,0 +1,24 @@
+# RA Lehne - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/RA_Mueller/05_verbindungen.md
+++ b/persons/RA_Mueller/05_verbindungen.md
@@ -1,0 +1,23 @@
+# RA Mueller - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/RA_Mueller/06_aussagen.md
+++ b/persons/RA_Mueller/06_aussagen.md
@@ -1,0 +1,19 @@
+# RA Mueller - Aussagen (Wortlaut)
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Struktur laut ANALYSE_ROUTINE angelegt
+
+---
+
+## Aussagen-Tabelle
+| Wortlaut (exakt) | Datum | Quelle Genesis (Dokument) | Quelle Factcheck (Audio) | Beweiswert (1-10) | Verwendung | Review-Status |
+|------------------|-------|---------------------------|--------------------------|-------------------|------------|---------------|
+| - | - | - | - | - | - | offen |
+
+---
+
+## Hinweise für die Befüllung
+- Exakte Zitate verwenden, mit Datum und Quelle.
+- Bei Audio immer Snippet/Datei referenzieren.
+- Verwendungszweck definieren (Anklage, Plädoyer, Presse, Petition).

--- a/persons/RA_Mueller/07_motive.md
+++ b/persons/RA_Mueller/07_motive.md
@@ -1,0 +1,24 @@
+# RA Mueller - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/RA_Robling/05_verbindungen.md
+++ b/persons/RA_Robling/05_verbindungen.md
@@ -1,0 +1,23 @@
+# RA Robling - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/RA_Robling/06_aussagen.md
+++ b/persons/RA_Robling/06_aussagen.md
@@ -1,0 +1,19 @@
+# RA Robling - Aussagen (Wortlaut)
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Struktur laut ANALYSE_ROUTINE angelegt
+
+---
+
+## Aussagen-Tabelle
+| Wortlaut (exakt) | Datum | Quelle Genesis (Dokument) | Quelle Factcheck (Audio) | Beweiswert (1-10) | Verwendung | Review-Status |
+|------------------|-------|---------------------------|--------------------------|-------------------|------------|---------------|
+| - | - | - | - | - | - | offen |
+
+---
+
+## Hinweise für die Befüllung
+- Exakte Zitate verwenden, mit Datum und Quelle.
+- Bei Audio immer Snippet/Datei referenzieren.
+- Verwendungszweck definieren (Anklage, Plädoyer, Presse, Petition).

--- a/persons/RA_Robling/07_motive.md
+++ b/persons/RA_Robling/07_motive.md
@@ -1,0 +1,24 @@
+# RA Robling - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/Rebecca_Wilhelm/01_dokumente.md
+++ b/persons/Rebecca_Wilhelm/01_dokumente.md
@@ -1,0 +1,24 @@
+# Rebecca Wilhelm - Dokumente
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basis-Stub gemäß ANALYSE_ROUTINE
+
+---
+
+## Dokumente (chronologisch)
+| Datum | Dokument | Inhalt/Bezug | Pfad/Quelle | Review-Status |
+|-------|----------|--------------|-------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Schlüsseldokumente (Hypothesen)
+- [ ] Relevante Akten aus extracted/ und evidence/ zuordnen.
+- [ ] Abgleich mit Audio-Snippets (falls vorhanden).
+
+---
+
+## Nächste Schritte
+- [ ] Dokumente nach Datum sortieren und bewerten.
+- [ ] Abweichungen zu offiziellen Aussagen markieren.

--- a/persons/Rebecca_Wilhelm/04_bewertung.md
+++ b/persons/Rebecca_Wilhelm/04_bewertung.md
@@ -1,0 +1,30 @@
+# Rebecca Wilhelm - Bewertung
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisbewertung angelegt
+
+---
+
+## Bewertungsstand
+- **Credibility Rating (vorläufig):** offen/10
+- **Rolle im Verfahren:** noch einordnen
+- **Aktuelle Einschätzung:** Platzhalter
+
+---
+
+## Zusammenfassung (wird fortgeschrieben)
+- Hinweise aus Dokumenten (01_dokumente) und Audio (02_audio) konsolidieren.
+- Diskrepanzen (03_diskrepanzen) priorisieren.
+
+---
+
+## Offene Fragen
+- [ ] Welche Belege stützen oder widerlegen die offizielle Version?
+- [ ] Welche Zeugen/Audios sind noch zu prüfen?
+
+---
+
+## Empfehlung für DB-Update
+- [ ] Rating und tatsächliche Rolle nach Review setzen.
+- [ ] Notes/Anmerkungen nach Abschluss ergänzen.

--- a/persons/Rebecca_Wilhelm/05_verbindungen.md
+++ b/persons/Rebecca_Wilhelm/05_verbindungen.md
@@ -1,0 +1,23 @@
+# Rebecca Wilhelm - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/Rebecca_Wilhelm/07_motive.md
+++ b/persons/Rebecca_Wilhelm/07_motive.md
@@ -1,0 +1,24 @@
+# Rebecca Wilhelm - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/Staatsanwalt_Carius/03_diskrepanzen.md
+++ b/persons/Staatsanwalt_Carius/03_diskrepanzen.md
@@ -1,0 +1,26 @@
+# Staatsanwalt Carius - Diskrepanz-Analyse
+
+**Erstellt:** 2025-12-24
+**Methode:** Vergleich offizielle Dokumente vs. Audio-Beweise
+**Review:** Basisstruktur vorbereitet
+
+---
+
+## Offiziell vs. Tatsächlich (Platzhalter)
+| Thema | Offizielle Version (Dokumente) | Tatsächlich (Audio/Belege) | Review-Status |
+|-------|--------------------------------|----------------------------|---------------|
+| - | - | - | offen |
+
+---
+
+## Diskrepanz-Backlog
+- [ ] Widersprüche zwischen 01_dokumente und 02_audio sammeln.
+- [ ] Konkrete Beispiele mit Zitaten ergänzen.
+- [ ] Beweiswerte für jede Diskrepanz notieren.
+
+---
+
+## Hinweise für die Auswertung
+- Beide Quellen (Dokumente + Audio) gleichberechtigt prüfen.
+- Datum, Quelle und Zitat immer mit angeben.
+- Review-Kommentare nach jedem Fund ergänzen.

--- a/persons/Staatsanwalt_Carius/05_verbindungen.md
+++ b/persons/Staatsanwalt_Carius/05_verbindungen.md
@@ -1,0 +1,23 @@
+# Staatsanwalt Carius - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/Staatsanwalt_Carius/07_motive.md
+++ b/persons/Staatsanwalt_Carius/07_motive.md
@@ -1,0 +1,24 @@
+# Staatsanwalt Carius - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.

--- a/persons/Susanne_Wilhelm/01_dokumente.md
+++ b/persons/Susanne_Wilhelm/01_dokumente.md
@@ -1,0 +1,24 @@
+# Susanne Wilhelm - Dokumente
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basis-Stub gemäß ANALYSE_ROUTINE
+
+---
+
+## Dokumente (chronologisch)
+| Datum | Dokument | Inhalt/Bezug | Pfad/Quelle | Review-Status |
+|-------|----------|--------------|-------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Schlüsseldokumente (Hypothesen)
+- [ ] Relevante Akten aus extracted/ und evidence/ zuordnen.
+- [ ] Abgleich mit Audio-Snippets (falls vorhanden).
+
+---
+
+## Nächste Schritte
+- [ ] Dokumente nach Datum sortieren und bewerten.
+- [ ] Abweichungen zu offiziellen Aussagen markieren.

--- a/persons/Susanne_Wilhelm/04_bewertung.md
+++ b/persons/Susanne_Wilhelm/04_bewertung.md
@@ -1,0 +1,30 @@
+# Susanne Wilhelm - Bewertung
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisbewertung angelegt
+
+---
+
+## Bewertungsstand
+- **Credibility Rating (vorläufig):** offen/10
+- **Rolle im Verfahren:** noch einordnen
+- **Aktuelle Einschätzung:** Platzhalter
+
+---
+
+## Zusammenfassung (wird fortgeschrieben)
+- Hinweise aus Dokumenten (01_dokumente) und Audio (02_audio) konsolidieren.
+- Diskrepanzen (03_diskrepanzen) priorisieren.
+
+---
+
+## Offene Fragen
+- [ ] Welche Belege stützen oder widerlegen die offizielle Version?
+- [ ] Welche Zeugen/Audios sind noch zu prüfen?
+
+---
+
+## Empfehlung für DB-Update
+- [ ] Rating und tatsächliche Rolle nach Review setzen.
+- [ ] Notes/Anmerkungen nach Abschluss ergänzen.

--- a/persons/Susanne_Wilhelm/05_verbindungen.md
+++ b/persons/Susanne_Wilhelm/05_verbindungen.md
@@ -1,0 +1,23 @@
+# Susanne Wilhelm - Verbindungen & Netzwerk
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisnetzwerk angelegt
+
+---
+
+## Schlüsselbeziehungen
+| Person/Institution | Beziehung | Quelle | Review-Status |
+|--------------------|-----------|--------|---------------|
+| - | - | - | offen |
+
+---
+
+## Hierarchie / Abhängigkeiten
+- [ ] Auftraggeber / Vorgesetzte identifizieren.
+- [ ] Kooperationspartner und Schutzgeber notieren.
+
+---
+
+## Visualisierung (optional)
+- [ ] ASCII- oder Cypher-Graph ergänzen, sobald Daten vorliegen.

--- a/persons/Susanne_Wilhelm/07_motive.md
+++ b/persons/Susanne_Wilhelm/07_motive.md
@@ -1,0 +1,24 @@
+# Susanne Wilhelm - Motive & Richtungswechsel
+
+**Erstellt:** 2025-12-24
+**Zuletzt geprüft:** offen
+**Review:** Basisstub nach 07_MOTIVE_ROUTINE
+
+---
+
+## Dokumentierte Richtungswechsel
+| Zeitpunkt | Verhalten/Entscheidung | Vermutetes Motiv | Beleg/Quelle | Review-Status |
+|-----------|-----------------------|------------------|--------------|---------------|
+| - | - | - | - | offen |
+
+---
+
+## Hypothesen (werden überprüft)
+- [ ] Motiv-Hypothesen mit Dokumenten und Audio abgleichen.
+- [ ] Veränderungen chronologisch einordnen.
+
+---
+
+## Offene Schritte
+- [ ] Reverse-Interview-Workflow anwenden.
+- [ ] Zusammenfassung der wichtigsten Motivwechsel erstellen.


### PR DESCRIPTION
## Summary
- add missing routine files across all person dossiers to match ANALYSE_ROUTINE structure
- provide baseline tables and review placeholders for Dokumente, Audio, Diskrepanzen, Bewertung, Verbindungen, Aussagen und Motive

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694b740260d083218a097d3f86480cf8)